### PR TITLE
Check for activity

### DIFF
--- a/android/src/main/java/com/applaudsoft/flutter_autofill/FlutterAutofillPlugin.java
+++ b/android/src/main/java/com/applaudsoft/flutter_autofill/FlutterAutofillPlugin.java
@@ -110,7 +110,7 @@ public class FlutterAutofillPlugin implements MethodCallHandler {
     }
 
     private void init() {
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+        if (registrar.activity() != null && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
             View decorView = registrar.activity().getWindow().getDecorView();
             ViewGroup rootView = decorView.findViewById(android.R.id.content);
             afm = registrar.activity().getSystemService(AutofillManager.class);


### PR DESCRIPTION
This fixes compatibility with other plugins that use background dart execution with no activity.